### PR TITLE
Fix bugs in create tasks server

### DIFF
--- a/app/task_queue/scheduler.py
+++ b/app/task_queue/scheduler.py
@@ -26,14 +26,17 @@ def start_scheduler(redis_url, redis_password=None, queue_name='job_scheduler_qu
         cron_string="* * * * *",  # once a minute
         func=log_review,
         args=[datetime.now(), choice(['Alice', 'Bob', 'Carol', 'Dave'])],
-        queue_name='basic_queue',
+        queue_name=queue.name,
         repeat=None
     )
     logger.info(f"Added job {job}")
+
+    return scheduler
 
 if __name__ == "__main__":
     print("about to start")
     url = environ.get('REDIS_URL')
     password = environ.get('REDIS_PASSWORD')  # will be None in development
     print("got env vars")
-    start_scheduler(url, password)
+    scheduler = start_scheduler(url, password)
+    scheduler.run()

--- a/tasks-start.sh
+++ b/tasks-start.sh
@@ -2,6 +2,8 @@
 
 cd /var/app
 
-#python app/task_queue/print_review.py
-python app/task_queue/scheduler.py
+# Since this is running multiple processes, 
+# run the first process in the background so
+# that the second process is launched.
+python app/task_queue/scheduler.py & 
 python app/task_queue/worker.py


### PR DESCRIPTION
There were a couple minor issues here.
* The scheduler needs to actually be run.
* The scheduler process needs to be launched in the background so that the worker process can run as well.
* The queue name was hardcoded rather than pulling from the input parameter so the job queue name didn't match the scheduler and worker queue names.

I'm just opening a draft PR so you can easily compare the changes. Feel free to close it once you've looked at them.